### PR TITLE
fix: btn state check

### DIFF
--- a/src/hooks/use-exchange-amounts.js
+++ b/src/hooks/use-exchange-amounts.js
@@ -59,7 +59,7 @@ export const calculateAmounts = ({
       }
   }
 
-  if (btn !== '' && noDecimalAssetNames.includes(toAssetName)) {
+  if (!!btn && noDecimalAssetNames.includes(toAssetName)) {
     let nonDecimalAmount = exchangeConversion(fromAmount)
     if (btn === 'min') {
       nonDecimalAmount = nonDecimalAmount.add(assets[toAssetName].currency.defaultUnit(1))


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

In mobile exchange `btn` default state is empty string. in FTX it's null. Wrong logic caused bug here
https://github.com/ExodusMovement/exodus-mobile/pull/9824

Added `!!btn` check to be ready for any value, but ideally need to refactor code to use `null` everywhere on client-side (can be achieved by using `useExchange` hook)