### PR TITLE
refactor: deep memoize result of amounts calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+# Idea IDE files
+.idea

--- a/src/hooks/use-exchange-amounts.js
+++ b/src/hooks/use-exchange-amounts.js
@@ -1,8 +1,8 @@
 import assets from '@exodus/assets'
 import { useMemo } from 'react'
+import { isEqual } from 'lodash'
 import useFormattedExchangeAmounts from './use-formatted-exchange-amounts'
 import useMemoCompare from './use-memo-compare'
-import { isEqual } from 'lodash'
 
 export const calculateAmounts = ({
   maxAmount,

--- a/src/hooks/use-exchange-amounts.js
+++ b/src/hooks/use-exchange-amounts.js
@@ -1,6 +1,8 @@
 import assets from '@exodus/assets'
 import { useMemo } from 'react'
 import useFormattedExchangeAmounts from './use-formatted-exchange-amounts'
+import useMemoCompare from './use-memo-compare'
+import { isEqual } from 'lodash'
 
 export const calculateAmounts = ({
   maxAmount,
@@ -112,7 +114,7 @@ const useExchangeAmounts = ({
   noDecimalAssetNames,
   formatAssetAmount,
 }) => {
-  const amounts = useMemo(
+  const _amounts = useMemo(
     () =>
       calculateAmounts({
         maxAmount,
@@ -143,6 +145,8 @@ const useExchangeAmounts = ({
       noDecimalAssetNames,
     ]
   )
+
+  const amounts = useMemoCompare(_amounts, isEqual)
 
   const formattedAmounts = useFormattedExchangeAmounts({
     ...amounts,

--- a/src/hooks/use-memo-compare.js
+++ b/src/hooks/use-memo-compare.js
@@ -1,0 +1,22 @@
+import { useRef, useEffect } from 'react'
+
+function useMemoCompare(next, compare) {
+  // Ref for storing previous value
+  const previousRef = useRef()
+  const previous = previousRef.current
+  // Pass previous and next value to compare function
+  // to determine whether to consider them equal.
+  const isEqual = compare(previous, next)
+  // If not equal update previousRef to next value.
+  // We only update if not equal so that this hook continues to return
+  // the same old value if compare keeps returning true.
+  useEffect(() => {
+    if (!isEqual) {
+      previousRef.current = next
+    }
+  })
+  // Finally, if equal then return the previous value
+  return isEqual ? previous : next
+}
+
+export default useMemoCompare


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

Depends on #6 

`calculateAmounts` may run on some hook deps changes, but amounts can be still the same in the result. since we create new number unit instance component re-renders. to fix it i check output and if it's the same return values from cache

## Test plan

`yarn watch ../exodus-desktop/src`
run desktop app and try to exchange

<!-- Demonstrate the code is solid. Example: The exact steps you followed to test it and their outcome. -->

## Further comments

<!--- Kick of a discussion about this change, if applicable. If not, delete this entire section. -->
